### PR TITLE
fix nav Home link CSS for Safari OS X

### DIFF
--- a/src/page-wrapper.js
+++ b/src/page-wrapper.js
@@ -143,7 +143,7 @@ const Header = (props) => (
     }}
   >
     <div>
-      <a href="/" css={{ display: "flex", flex: 1, marginTop: "7px" }}>
+      <a href="/" css={{ flex: 1, marginTop: "7px" }}>
         <img src="/toast.jpg" css={{ width: "50px" }} />
       </a>
     </div>


### PR DESCRIPTION
![buggy layout screenshot](https://user-images.githubusercontent.com/6597211/87376917-06fa2d00-c5b6-11ea-896d-874e70f1f98d.png)

This PR fixes the stretched Home link in Safari 12.